### PR TITLE
Add pre-commit configuration for shell and docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: shellcheck
+        args: ["-S", "style"]
+        files: "\\.(sh|bash)$"
+      - id: shfmt
+        args: ["-i", "2", "-ci", "-sr"]
+        files: "\\.(sh|bash)$"
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.43.0
+    hooks:
+      - id: markdownlint
+        files: "\\.(md|mdx)$"
+  - repo: https://github.com/errata-ai/vale
+    rev: v3.8.0
+    hooks:
+      - id: vale
+        args: ["--no-exit", "."]
+        files: "\\.(md|mdx)$"


### PR DESCRIPTION
## Summary
- add a pre-commit configuration to run shellcheck, shfmt, markdownlint, and Vale

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a5a8169c832c811c1c65b24df4be