### PR TITLE
Fix env doctor tests on non-Termux platforms

### DIFF
--- a/tests/env.bats
+++ b/tests/env.bats
@@ -25,13 +25,13 @@ setup() {
   unset TERMUX_VERSION
   run wgx env doctor --fix
   assert_success
-  assert_output --stderr --partial "only supported on Termux"
+  assert_output --stderr --partial "--fix is currently only supported on Termux"
 }
 
 @test "env doctor --strict fails when git is missing" {
   local tmpbin
   tmpbin="$(mktemp -d)"
-  for cmd in dirname readlink uname head tr; do
+  for cmd in bash dirname readlink uname head tr; do
     ln -s "$(command -v "$cmd")" "$tmpbin/$cmd"
   done
   run env PATH="$tmpbin" "$WGX_DIR/cli/wgx" env doctor --strict


### PR DESCRIPTION
## Summary
- update the env doctor --fix test to match the current warning emitted outside Termux
- ensure the strict-mode test provides a bash binary when PATH is minimised so the CLI can launch

## Testing
- not run (bats is not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0cddbeff4832c8ad1f375e13ea768