### PR TITLE
Ensure env doctor --fix warns outside Termux

### DIFF
--- a/modules/env.bash
+++ b/modules/env.bash
@@ -142,7 +142,7 @@ env::_apply_fixes() {
     return 1
   fi
 
-  warn "--fix is currently only supported on Termux"
+  printf '⚠️  %s\n' "--fix is currently only supported on Termux" >&2
   return 0
 }
 


### PR DESCRIPTION
## Summary
- ensure the env doctor --fix path always writes the Termux-only warning to stderr

## Testing
- cli/wgx env doctor --fix

------
https://chatgpt.com/codex/tasks/task_e_68e1a8179ef4832ca4dbe5a376bee88d