### PR TITLE
Fix env doctor --fix message outside Termux

### DIFF
--- a/modules/env.bash
+++ b/modules/env.bash
@@ -142,7 +142,7 @@ env::_apply_fixes() {
     return 1
   fi
 
-  printf '⚠️  %s\n' "--fix is currently only supported on Termux" >&2
+  printf '%s\n' "--fix is currently only supported on Termux" >&2
   return 0
 }
 


### PR DESCRIPTION
## Summary
- ensure `wgx env doctor --fix` emits the expected Termux-only warning when run outside Termux

## Testing
- bats tests/env.bats *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e208111390832cbec68af70c16534a