### PR TITLE
Ensure CI workflow exposes tests change detection output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       shell: ${{ steps.filter.outputs.shell }}
+      tests: ${{ steps.filter.outputs.tests }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- expose the `tests` filter result from the changes job so downstream CI jobs can detect test-only modifications

## Testing
- ./wgx lint
- ./wgx test --list

------
https://chatgpt.com/codex/tasks/task_e_68e218745c34832c85442fc169c082f6