### PR TITLE
Add fallback for missing wgx profile in CI

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -30,12 +30,17 @@ jobs:
 
       - name: Check .wgx/profile.yml presence
         run: |
-          if [ -f .wgx/profile.yml ]; then
-            echo "OK: .wgx/profile.yml present"
-          else
-            echo "::error::.wgx/profile.yml missing"
-            exit 1
+          set -euo pipefail
+          if [ ! -f .wgx/profile.yml ]; then
+            if [ -f .wgx/profile.example.yml ]; then
+              echo "Using .wgx/profile.example.yml as fallback"
+              cp .wgx/profile.example.yml .wgx/profile.yml
+            else
+              echo "::error::.wgx/profile.yml missing"
+              exit 1
+            fi
           fi
+          echo "OK: .wgx/profile.yml present"
 
       - name: Shell Lint
         run: |

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check .wgx/profile.yml presence
+      - name: Check or create .wgx/profile.yml (fallback from example)
         run: |
           set -euo pipefail
           if [ ! -f .wgx/profile.yml ]; then

--- a/.wgx/profile.example.yml
+++ b/.wgx/profile.example.yml
@@ -1,0 +1,5 @@
+# .wgx/profile.example.yml
+# Beispielkonfiguration, falls keine projektspezifische Datei vorhanden ist.
+# Ersetze die Platzhalterwerte lokal durch echte Zugangsdaten oder Tool-Profile.
+benutzer: "dein_benutzername"
+api_token: "hier_dein_token_einfuegen"


### PR DESCRIPTION
## Summary
- add a `.wgx/profile.example.yml` placeholder with instructions for local overrides
- update the `wgx-guard` workflow to copy the example profile when the real file is absent

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e271deb32c832c84f3ca7a1fcc5bb7