### PR TITLE
Use install-action for shell linters

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -37,6 +37,16 @@ jobs:
             exit 1
           fi
 
+      - name: Install shellcheck (cached)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: shellcheck
+
+      - name: Install shfmt (cached)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: shfmt
+
       - name: Shell Lint
         run: |
           set -euo pipefail
@@ -45,8 +55,6 @@ jobs:
             echo "No shell scripts found; skipping lint."
             exit 0
           fi
-          sudo apt-get update -y -qq
-          sudo apt-get install -y -qq shellcheck shfmt
           bash -n "${scripts[@]}"
           shfmt -d "${scripts[@]}"
           shellcheck -S style "${scripts[@]}"


### PR DESCRIPTION
## Summary
- install shellcheck and shfmt via taiki-e/install-action for cached binaries
- remove apt-get installs and keep shell lint step focused on running the linters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e273abd084832cabe3687945a89bb8