### PR TITLE
Ensure env doctor --fix warning uses stderr

### DIFF
--- a/modules/env.bash
+++ b/modules/env.bash
@@ -132,6 +132,10 @@ env::_termux_fixups() {
   return $rc
 }
 
+env::_fix_unsupported_msg() {
+  printf '%s\n' "--fix is currently only supported on Termux" >&2
+}
+
 env::_apply_fixes() {
   if env::_is_termux; then
     if env::_termux_fixups; then
@@ -142,7 +146,7 @@ env::_apply_fixes() {
     return 1
   fi
 
-  printf '%s\n' "--fix is currently only supported on Termux" >&2
+  env::_fix_unsupported_msg
   return 0
 }
 
@@ -189,7 +193,7 @@ USAGE
     if env::_is_termux; then
       apply_fixes=1
     else
-      printf '%s\n' "--fix is currently only supported on Termux" >&2
+      env::_fix_unsupported_msg
     fi
   fi
 


### PR DESCRIPTION
## Summary
- add a shared helper to print the Termux-only --fix warning to stderr
- reuse the helper so the warning is consistently emitted on stderr

## Testing
- bats tests/env.bats *(fails: command not found: bats)*

------
https://chatgpt.com/codex/tasks/task_e_68e2780388f4832c8cd000211ccf99a6