### PR TITLE
Fix env doctor Termux test assertion

### DIFF
--- a/tests/env.bats
+++ b/tests/env.bats
@@ -25,7 +25,7 @@ setup() {
   unset TERMUX_VERSION
   run wgx env doctor --fix
   assert_success
-  assert_output --stderr --partial "--fix is currently only supported on Termux"
+  assert_output --partial "--fix is currently only supported on Termux"
 }
 
 @test "env doctor --strict fails when git is missing" {


### PR DESCRIPTION
## Summary
- update the env doctor --fix test to check for the Termux warning on standard output

## Testing
- not run (bats not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e27a6c23a0832cb37ac894af72a212