### PR TITLE
Fix security workflow token requirement

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,6 +39,8 @@ jobs:
       # Use pre-built action for cargo-audit to avoid repeated compilation
       - name: Audit dependencies
         uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       # Optional: falls du ein eigenes DB-Verzeichnis nutzt
       # - name: Audit with explicit DB path
       #   run: cargo audit -d ~/.cargo/advisory-db


### PR DESCRIPTION
## Summary
- provide the required `token` input to the audit dependencies step in the security workflow
- use the default `GITHUB_TOKEN` secret to satisfy the action requirement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27a29e0dc832ca65d0bb627f2dcb1