### PR TITLE
Add ultra-fast repo smoke to guard workflow

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -74,7 +74,7 @@ jobs:
             cargo metadata --no-deps >/dev/null
           fi
           if [ -f pyproject.toml ]; then
-            grep -q '^\[project\]' pyproject.toml || echo "::warning::[project] section not found in pyproject.toml"
+            grep -q '^[[:space:]]*\[project\]' pyproject.toml || echo "::warning::[project] section not found in pyproject.toml"
           fi
 
       - name: Check .wgx profile presence

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -65,6 +65,18 @@ jobs:
           install_bash || exit 1
           bash --version
 
+      - name: Repo smoke (ultra-fast)
+        run: |
+          set -euo pipefail
+          echo "ref=${{ github.ref }} sha=${{ github.sha }}"
+          test -s README.md || echo "::warning::README.md missing or empty"
+          if [ -f Cargo.toml ]; then
+            cargo metadata --no-deps >/dev/null
+          fi
+          if [ -f pyproject.toml ]; then
+            grep -q '^\[project\]' pyproject.toml || echo "::warning::[project] section not found in pyproject.toml"
+          fi
+
       - name: Check .wgx profile presence
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- add a lightweight smoke step to the guard workflow
- record repo ref/sha and emit warnings for missing README or Python metadata
- reuse existing conditional Rust metadata check to keep the step fast

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e28f2841a0832c9798bf5837fff1c4