### PR TITLE
Handle missing cargo in guard smoke check

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -71,7 +71,11 @@ jobs:
           echo "ref=${{ github.ref }} sha=${{ github.sha }}"
           test -s README.md || echo "::warning::README.md missing or empty"
           if [ -f Cargo.toml ]; then
-            cargo metadata --no-deps >/dev/null
+            if command -v cargo >/dev/null 2>&1; then
+              cargo metadata --no-deps >/dev/null
+            else
+              echo "::notice::Cargo.toml present but 'cargo' not found – skipping Rust smoke"
+            fi
           fi
           if [ -f pyproject.toml ]; then
             grep -q '^[[:space:]]*\[project\]' pyproject.toml || echo "::warning::[project] section not found in pyproject.toml"


### PR DESCRIPTION
## Summary
- skip the repo smoke Cargo metadata probe when cargo is unavailable
- emit a notice when Cargo.toml exists but cargo is missing so the workflow stays informative

## Testing
- not run (CI workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68e2921179a8832c96adabe43264eb65